### PR TITLE
Further dialed back NumPy requirements for readthedocs compatibility.…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # dev environment
-setuptools~=60.2.0
-twine~=4.0.1
-sphinx~=5.3.0
-sphinx-rtd-theme~=1.1.1
+setuptools~=60.2
+twine~=4.0
+sphinx~=5.3
+sphinx-rtd-theme~=1.1
 # Jupyter notebooks
-pytz~=2022.2.1
+pytz~=2022.2
 # true package dependencies
-boto3~=1.24.77
-botocore~=1.27.77
-requests~=2.28.1
-pandas~=1.3.5
-numpy>=1.22
+boto3~=1.24
+botocore~=1.27
+requests~=2.28
+pandas~=1.3
+numpy~=1.21


### PR DESCRIPTION
… Also stopped requiring such precise versions of dependencies.